### PR TITLE
General style changes

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -67,3 +67,10 @@
     transition-delay: 0.10;
   }
 }
+
+img.listing-card-image {
+    height: 200px;
+    width: 100%;
+    object-fit: cover;
+    object-position: 50% 50%;
+}

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -5,10 +5,12 @@
       <% @listings.each do |listing| %>
         <div class="card text-center">
           <%= link_to listing_path(listing) do %>
-            <%= cl_image_tag listing.photos[0].key, class: "w-100", height: 200, crop: :fill  %>
-            <div class="card-body">
-              <h5 class="card-title"><%= listing.title.capitalize %> </h5>
-              <p>£<%= listing.rate %></p>
+            <div class="listing-card">
+              <%= cl_image_tag listing.photos[0].key, class: "listing-card-image"  %>
+              <div class="card-body">
+                <h5 class="card-title"><%= listing.title.capitalize %> </h5>
+                <p>£<%= listing.rate %></p>
+              </div>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
Fix images on listing page (stop them from stretching)

<img width="1204" alt="Screenshot 2020-11-20 at 12 18 17" src="https://user-images.githubusercontent.com/16326211/99799409-82528900-2b2a-11eb-875c-5d2028c3736a.png">
